### PR TITLE
update Revene chart

### DIFF
--- a/src/components/SearchResult/Chart/EpsChart.tsx
+++ b/src/components/SearchResult/Chart/EpsChart.tsx
@@ -160,7 +160,7 @@ const EpsChart = () => {
     };
   }, [data]);
 
-  if (isLoading) return <p>Loading...</p>;
+  if (isLoading) return <div className="text-center text-lg h-[400px]">Loading...</div>;
   if (!data || data.length === 0) return <p>No data available.</p>;
 
   return (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Revenue chart now groups data by quarter and year with dual X‑axis labels for clearer trends.
  * Added a custom tooltip displaying quarter and year.
  * Limits the chart to the most recent 30 data points for improved readability.
  * Loads revenue data only when a query is present, avoiding empty states.

* **Style**
  * Enhanced EPS chart loading state: centered, larger text with a consistent chart-height placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->